### PR TITLE
Fixing dashes in attribute-values

### DIFF
--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -25,7 +25,7 @@ function textToken(content: string) {
     return new Token(TokenType.Text, content);
 }
 
-var attrNameChars = "[a-zA-Z0-9\.\-_:;]";
+var attrNameChars = "[a-zA-Z0-9\.\\-_:;]";
 //var attrNameChars = "\\w";
 var attrValueChars = attrNameChars;
 


### PR DESCRIPTION
Hi. There was a backslash missing that prevented attribute-values holding dashes to get parsed.
