### PR TITLE
Changed tokenizer attributeValue to regex allowing evertything except ' and " 

### DIFF
--- a/src/bbCodeParser.ts
+++ b/src/bbCodeParser.ts
@@ -122,7 +122,7 @@ class BBCodeParser {
             var link = content;
 
             if (attr["url"] != undefined) {
-                link = escapeHTML(attr["url"]);
+                link = attr["url"];
             }
 
             if (!startsWith(link, "http://") && !startsWith(link, "https://")) {

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -49,6 +49,12 @@ class TestTokenizer extends tsUnit.TestClass {
         this.isTrue(new Token(TokenType.StartTag, "url").equals(tokens[0]));
         this.isTrue(new Token(TokenType.Text, "Google.se").equals(tokens[1]));
         this.isTrue(new Token(TokenType.EndTag, "url").equals(tokens[2]));
+        
+        tokens = tokenizer.tokenizeString("[url=\"http://google.se/search?q=google&oq=google\"]Google.se[/url]");
+        this.isTrue(new Token(TokenType.StartTag, "url").equals(tokens[0]));
+        this.isTrue("http://google.se/search?q=google&oq=google" === tokens[0].tagAttributes['url']);
+        this.isTrue(new Token(TokenType.Text, "Google.se").equals(tokens[1]));
+        this.isTrue(new Token(TokenType.EndTag, "url").equals(tokens[2]));
     }
 
     testBuildTree() {
@@ -137,6 +143,9 @@ class TestTokenizer extends tsUnit.TestClass {
         htmlStr = parser.parseString("[url=\"http://google.se\"]Google.se[/url]");
         this.areIdentical("<a href=\"http://google.se\" target=\"_blank\">Google.se</a>", htmlStr);
 
+        htmlStr = parser.parseString("[url url=\"http://google.se/search?q=google&oq=google\"]Google.se[/url]");
+        this.areIdentical("<a href=\"http://google.se/search?q=google&oq=google\" target=\"_blank\">Google.se</a>", htmlStr);
+
         //Test invalid
         htmlStr = parser.parseString("[b]test[]");
         this.areIdentical("[b]test[]", htmlStr);
@@ -168,7 +177,7 @@ class TestTokenizer extends tsUnit.TestClass {
     }
 
     testEscapingHtmlOption() {
-        var parser = new BBCodeParser(BBCodeParser.defaultTags());
+        var parser = new BBCodeParser(BBCodeParser.defaultTags(), { escapeHTML: true });
         var htmlStr = parser.parseString('[b]String[/b] with <a href="">html</a><br/>')
         this.areIdentical('<b>String</b> with &lt;a href=""&gt;html&lt;/a&gt;&lt;br/&gt;', htmlStr);
 

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -27,7 +27,7 @@ function textToken(content: string) {
 
 var attrNameChars = "[a-zA-Z0-9\\.\\-_:;/]";
 //var attrNameChars = "\\w";
-var attrValueChars = "[a-zA-Z0-9\\.\\-_:;#/\\s]";
+var attrValueChars = "[^\'\"]";
 
 //Creates a new tag token
 function tagToken(match) {


### PR DESCRIPTION
Changed tokenizer attributeValue to regex allowing evertything except ' and " which determines end of attribute value. Added suitable unit tests and fixed one of already exiting which was incorrect.